### PR TITLE
fix: CORS origin default to 5173, add CORS_ORIGIN to docker-compose, …

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,6 +31,7 @@ services:
       DB_NAME: delivery_db
       JWT_SECRET: ${JWT_SECRET}
       PORT: "8080"
+      CORS_ORIGIN: "http://localhost:5173" 
     depends_on:
       db:
         condition: service_healthy

--- a/internal/handler/health_test.go
+++ b/internal/handler/health_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/gin-gonic/gin"
@@ -42,7 +43,7 @@ func TestHealth_Check_Healthy(t *testing.T) {
 	db, cleanup, _ := setupMockGormDB(t)
 	defer cleanup()
 
-	h := NewHealthHandler(db)
+	h := NewHealthHandler(db, "test", time.Now())
 
 	r := gin.New()
 	r.GET("/health", h.Check)
@@ -87,7 +88,7 @@ func TestHealth_Check_Unhealthy_WhenPingFails(t *testing.T) {
 	// Ping を失敗させる（DBをCloseすると Ping が connection refused 相当で失敗する）
 	closeDB()
 
-	h := NewHealthHandler(db)
+	h := NewHealthHandler(db, "test", time.Now())
 
 	r := gin.New()
 	r.GET("/health", h.Check)

--- a/internal/middleware/cors.go
+++ b/internal/middleware/cors.go
@@ -1,6 +1,7 @@
 package middleware
 
 import (
+	"log"
 	"os"
 
 	"github.com/gin-gonic/gin"
@@ -11,7 +12,7 @@ func CORSMiddleware() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		allowOrigin := os.Getenv("CORS_ORIGIN")
 		if allowOrigin == "" {
-			allowOrigin = "http://localhost:3000"
+			log.Fatal("CORS_ORIGIN is not set")
 		}
 		c.Writer.Header().Set("Access-Control-Allow-Origin", allowOrigin)
 		c.Writer.Header().Set("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS")


### PR DESCRIPTION
レビュー指摘されたCORSのデフォルトorigin修正、docker-compose.ymlにCORS_ORIGINを追加。health_test.goのNewHealthHandlerの引数を修正しました。

