### PR TITLE
Feature/auth refresh

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -100,11 +100,12 @@ func main() {
 		})
 	})
 
-	// 認証ルート（認証不要）
+	// 認証関連ルート（jwtトークン不要）
 	auth := r.Group("/api/v1/auth")
 	{
 		auth.POST("/register", authHandler.Register)
 		auth.POST("/login", authHandler.Login)
+		auth.POST("/refresh", authHandler.Refresh)
 	}
 
 	// ⭐ 認証が必要なルート
@@ -115,6 +116,7 @@ func main() {
 		// ここに認証が必要なエンドポイントを追加していく（次のIssueで）
 		api.GET("/users/me", userHandler.GetMe)
 		api.POST("/auth/logout", authHandler.Logout)
+
 	}
 
 	// ポート8080で起動

--- a/internal/handler/auth_handler.go
+++ b/internal/handler/auth_handler.go
@@ -84,7 +84,7 @@ func (h *AuthHandler) Register(c *gin.Context) {
 
 	setAuthCookie(c, token, h.secureCookie)
 
-	c.JSON(http.StatusCreated, gin.H{"id": user.ID})
+	c.JSON(http.StatusCreated, gin.H{"user": toUserResponse(user)})
 }
 
 func (h *AuthHandler) Login(c *gin.Context) {

--- a/internal/handler/auth_handler.go
+++ b/internal/handler/auth_handler.go
@@ -49,6 +49,7 @@ func toUserResponse(u *model.User) UserResponse {
 }
 
 func setAuthCookie(c *gin.Context, token string, secure bool) {
+	c.SetSameSite(http.SameSiteLaxMode)
 	c.SetCookie(
 		"auth_token",
 		token,
@@ -113,13 +114,14 @@ func (h *AuthHandler) Login(c *gin.Context) {
 }
 
 func (h *AuthHandler) Logout(c *gin.Context) {
+	c.SetSameSite(http.SameSiteLaxMode)
 	c.SetCookie(
 		"auth_token",
 		"",
 		-1,
 		"/",
 		"",
-		false,
+		h.secureCookie,
 		true,
 	)
 	c.JSON(http.StatusOK, gin.H{"message": "ログアウト成功"})

--- a/internal/handler/auth_handler.go
+++ b/internal/handler/auth_handler.go
@@ -126,3 +126,23 @@ func (h *AuthHandler) Logout(c *gin.Context) {
 	)
 	c.JSON(http.StatusOK, gin.H{"message": "ログアウト成功"})
 }
+
+func (h *AuthHandler) Refresh(c *gin.Context) {
+	//cookieからtokenを取得
+	token, err := c.Cookie("auth_token")
+	if err != nil {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "認証が必要です。"})
+		return
+	}
+
+	//トークンを検証して新しいトークンを発行
+	newToken, user, err := h.authService.Refresh(token)
+
+	if err != nil {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "セッションの有効期限が切れました"})
+		return
+	}
+
+	setAuthCookie(c, newToken, h.secureCookie)
+	c.JSON(http.StatusOK, gin.H{"user": toUserResponse(user)})
+}

--- a/internal/middleware/cors.go
+++ b/internal/middleware/cors.go
@@ -15,7 +15,7 @@ func CORSMiddleware() gin.HandlerFunc {
 		}
 		c.Writer.Header().Set("Access-Control-Allow-Origin", allowOrigin)
 		c.Writer.Header().Set("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS")
-		c.Writer.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization")
+		c.Writer.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization, X-Requested-With")
 		c.Writer.Header().Set("Access-Control-Allow-Credentials", "true")
 
 		// プリフライトリクエストの処理

--- a/internal/service/auth_service.go
+++ b/internal/service/auth_service.go
@@ -89,3 +89,27 @@ func (s *AuthService) Register(email, password, name, role, company, phone strin
 	}
 	return user, token, nil
 }
+
+func (s *AuthService) Refresh(tokenString string) (*model.User, string, error) {
+	//トークンを検証してuserIDを取得
+	claims, err := util.ParseToken(tokenString, s.jwtSecret)
+
+	if err != nil {
+		return nil, "", ErrInvalidCredentials
+	}
+
+	//ユーザーを取得
+	user, err := s.repo.GetByID(claims.UserID)
+	if err != nil {
+		return nil, "", ErrInvalidCredentials
+	}
+
+	//新しいトークンを発行
+	newToken, err := util.GenerateToken(user.ID, user.Email, user.Role, s.jwtSecret)
+	if err != nil {
+		return nil, "", err
+	}
+
+	return user, newToken, nil
+
+}


### PR DESCRIPTION
## 概要
トークンリフレッシュエンドポイントの実装

## 変更内容
- POST /auth/refresh エンドポイントを追加
- AuthHandler.Refresh() を実装
- AuthService.Refresh() を実装（ParseToken → GetByID → GenerateToken）
- /auth/refresh を認証不要グループに配置

## 動作
1. クライアントが /auth/refresh にPOSTを送る（Cookieを自動送信）
2. サーバーがトークンを検証してユーザーを取得
3. 新しいトークンをSet-Cookieで返す

## 完了条件
- [ ] POST /auth/refresh でトークンが更新される
- [ ] 無効なトークンの場合401を返す